### PR TITLE
mr- add Holiday Service Controller and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysController.java
@@ -2,8 +2,40 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.PublicHolidayQueryService;
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Extract public holidays")
 @RestController
+@RequestMapping("/api/publicholidays")
 public class PublicHolidaysController {
     
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    PublicHolidayQueryService publicHolidayQueryService;
+
+    @Operation(summary = "Get the list of public holidays for a historical year for a country ")
+    @GetMapping("/get")
+    public ResponseEntity<String> getHolidays(@Parameter(name="countryCode", description="country code", example="US") @RequestParam String countryCode,
+        @Parameter(name="year", description="string of a specific year you want to query", example="2022") @RequestParam String year
+    ) throws JsonProcessingException {
+        //log.info("getHolidays: year={} countryCode={}", year, countryCode);
+        String result = publicHolidayQueryService.getJSON(year,countryCode);
+        return ResponseEntity.ok().body(result);
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidayControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidayControllerTests.java
@@ -1,0 +1,60 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.PublicHolidayQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+
+@WebMvcTest(value = PublicHolidaysController.class)
+public class PublicHolidayControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  PublicHolidayQueryService mockPublicHolidayQueryService;
+
+
+  @Test
+  public void test_getPublicHolidays() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String year = "2022";
+    String countryCode = "US";
+    when(mockPublicHolidayQueryService.getJSON(eq(year),eq(countryCode))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/publicholidays/get?year=%s&countryCode=%s",year, countryCode);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/PublicHolidayQueryServiceTests.java
@@ -26,7 +26,7 @@ public class PublicHolidayQueryServiceTests {
 
 
         String countryCode = "US";
-        String year=  "2023";
+        String year=  "2022";
         String expectedURL = publicHolidayQueryService.ENDPOINT.replace("{year}", year)
                 .replace("{countryCode}", countryCode);
 


### PR DESCRIPTION
Closes #11 In this PR. Adds an endpoint `/api/publicholidays/get` that can be used to get information
about the public holidays in a country for a given year. We can get this by inputting the abbreviated country code and the year into the parameters of the request. Link to this is @ http://team01-madhav-ucsb-dev.dokku-09.cs.ucsb.edu/swagger-ui/index.html